### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -29,13 +29,13 @@ class syntax_plugin_sapnotelink extends DokuWiki_Syntax_Plugin {
 		$this->Lexer->addSpecialPattern('sap#[0-9]{1,10}',$mode,'plugin_sapnotelink');
     }
 
-    public function handle($match, $state, $pos, Doku_Handler &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array($match, $state);
 
         return $data;
     }
 		
-	public function render($mode, Doku_Renderer &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		# Dokuwiki Renderer
         if($mode == 'xhtml'){
             $sapnote = explode('#', $data[0]);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.